### PR TITLE
フォローユーザの取得をfrineds/idsに切り替え、未登録ユーザはDBに登録するようにした

### DIFF
--- a/server/apis/catalogue.js
+++ b/server/apis/catalogue.js
@@ -1,9 +1,9 @@
 import redis from '../models/redis'
-import {fetchFriends} from '../models/twitter'
+import {fetchTwitterFriendIds} from '../models/twitter'
 import {
   fetchBookmarkIds, fetchBySpaceIds,
   fetchRecommendUserListWithSpaceByEvent, fetchRecommendUserListWithSpaceByFriends,
-  fetchUserListWithSpaceByEventAndFriendList
+  fetchUserListWithSpaceByEventAndFriendIds
 } from '../models/catalogue'
 import {fetchEventByAlternateId} from '../models/event'
 
@@ -27,8 +27,8 @@ async function fetchAnonymousCatalogue(event) {
 }
 
 async function fetchLoggedInCatalogue(event, user) {
-  const friendList = await fetchFriendList(...pickTwitterAuth(user))
-  const friends = await fetchUserListWithSpaceByEventAndFriendList(event, friendList)
+  const friendIds = await fetchFriendIds(...pickTwitterAuth(user))
+  const friends = await fetchUserListWithSpaceByEventAndFriendIds(event, friendIds)
   const recommends = await fetchRecommendUserListWithSpaceByFriends(event, friends)
   const bookmarkIds = await fetchBookmarkIds(user, event)
   const bookmarks = await fetchBySpaceIds(bookmarkIds)
@@ -51,58 +51,58 @@ function formatCircles(event, circles, bookmarkIds = []) {
 }
 
 /**
- * friendListを取得
+ * friendIdsを取得
  * @param twitterId
  * @param twitterTokenKey
  * @param twitterTokenSecret
  * @returns {Promise.<Object>}
  */
-function fetchFriendList(twitterId, twitterTokenKey, twitterTokenSecret) {
+function fetchFriendIds(twitterId, twitterTokenKey, twitterTokenSecret) {
   return Promise.resolve().then(() => {
-    return fetchFriendListFromRedis(twitterId)
-  }).then(friendList => {
-    return friendList || fetchFriendListFromTwitterAPI(twitterId, twitterTokenKey, twitterTokenSecret)
+    return fetchFriendIdsFromRedis(twitterId)
+  }).then(friendIds => {
+    return friendIds || fetchFriendIdsFromTwitterAPI(twitterId, twitterTokenKey, twitterTokenSecret)
   })
 }
 
 /**
- * redisからfriendListを取得する処理
+ * redisからFriendIdsを取得する処理
  * @param twitterId
  * @returns {Promise.<Object>}
  */
-function fetchFriendListFromRedis(twitterId) {
+function fetchFriendIdsFromRedis(twitterId) {
   return Promise.resolve().then(() => {
-    return redis.get(`friendList::${twitterId}`)
-  }).then(friendList => {
-    return JSON.parse(friendList)
+    return redis.get(`friendIds::${twitterId}`)
+  }).then(friendIds => {
+    return JSON.parse(friendIds)
   })
 }
 
 /**
- * twitterAPIからfriendListを取得する処理
+ * twitterAPIからFriendIdsを取得する処理
  * @param twitterId
  * @param twitterTokenKey
  * @param twitterTokenSecret
  * @returns {Promise.<Object>}
  */
-function fetchFriendListFromTwitterAPI(twitterId, twitterTokenKey, twitterTokenSecret) {
-  return fetchFriends(twitterId, twitterTokenKey, twitterTokenSecret).then(friendList => {
-    return cacheFriendListToRedis(twitterId, friendList)
+function fetchFriendIdsFromTwitterAPI(twitterId, twitterTokenKey, twitterTokenSecret) {
+  return fetchTwitterFriendIds(twitterId, twitterTokenKey, twitterTokenSecret).then(friendIds => {
+    return cacheFriendIdsToRedis(twitterId, friendIds)
   })
 }
 
 /**
- * friendListを15分間Redisにキャッシュする処理
+ * FriendIdsを15分間Redisにキャッシュする処理
  * @param twitterId
- * @param friendList
+ * @param friendIds
  * @returns {Promise.<Object>}
  */
-function cacheFriendListToRedis(twitterId, friendList) {
+function cacheFriendIdsToRedis(twitterId, friendIds) {
   return Promise.resolve().then(() => {
-    return redis.set(`friendList::${twitterId}`, JSON.stringify(friendList))
+    return redis.set(`friendIds::${twitterId}`, JSON.stringify(friendIds))
   }).then(() => {
-    return redis.expire(`friendList::${twitterId}`, 60 * 15)
+    return redis.expire(`friendIds::${twitterId}`, 60 * 15)
   }).then(() => {
-    return friendList
+    return friendIds
   })
 }

--- a/server/models/catalogue.js
+++ b/server/models/catalogue.js
@@ -124,3 +124,7 @@ export function updateUsersByTwitterUserList(users, friendList) {
     }
   }))
 }
+
+export function createUsersByTwitterUserList(friendList) {
+  return User.bulkCreate(friendList)
+}

--- a/server/models/catalogue.js
+++ b/server/models/catalogue.js
@@ -114,10 +114,10 @@ export function updateUsersByTwitterUserList(users, friendList) {
     if (friend &&
       (user.name !== friend.name ||
         user.twitterName !== friend.twitterName ||
-        user.imageUrl !== friend.image)) {
+        user.imageUrl !== friend.imageUrl)) {
       user.name = friend.name
       user.twitterName = friend.twitterName
-      user.imageUrl = friend.image
+      user.imageUrl = friend.imageUrl
       return user.save().then(() => user)
     } else {
       return user

--- a/server/models/catalogue.js
+++ b/server/models/catalogue.js
@@ -45,8 +45,7 @@ export function fetchRecommendUserListWithSpaceByFriends(event, friends) {
   }).then(formatUsers)
 }
 
-export function fetchUserListWithSpaceByEventAndFriendList(event, friendList) {
-  const twitterIds = friendList.map(friend => friend.twitterId)
+export function fetchUserListWithSpaceByEventAndFriendIds(event, friendIds) {
   return User.findAll({
     attributes: ['id', 'name', 'imageUrl', 'twitterId', 'twitterName'],
     include: [{
@@ -56,7 +55,7 @@ export function fetchUserListWithSpaceByEventAndFriendList(event, friendList) {
       through: {attributes: []}
     }],
     where: {
-      twitterId: {[Op.in]: twitterIds}
+      twitterId: {[Op.in]: friendIds}
     },
     order: [
       [Space, 'date', 'ASC'],

--- a/server/models/twitter.js
+++ b/server/models/twitter.js
@@ -89,6 +89,6 @@ export async function lookupUsers(ids) {
     name: user.name, // 例：なのくろ
     twitterId: user['id_str'],
     twitterName: user['screen_name'], // 例：nanocloudx
-    image: convertTwitterImageUrl(user['profile_image_url_https'])
+    imageUrl: convertTwitterImageUrl(user['profile_image_url_https'])
   }))
 }

--- a/server/models/twitter.js
+++ b/server/models/twitter.js
@@ -1,7 +1,7 @@
 import Twitter from 'twitter'
 import {convertTwitterImageUrl} from '../utils/util'
 
-export function fetchFriends(twitterId, tokenKey, tokenSecret) {
+export function fetchTwitterFriendIds(twitterId, tokenKey, tokenSecret) {
   const client = new Twitter({
     consumer_key: process.env.TWITTER_CONSUMER_KEY,
     consumer_secret: process.env.TWITTER_CONSUMER_SECRET,
@@ -9,30 +9,22 @@ export function fetchFriends(twitterId, tokenKey, tokenSecret) {
     access_token_secret: tokenSecret
   })
   return new Promise((resolve, reject) => {
-    let friendsList = []
+    let friendIdsList = []
     let limitCounter = 0
     function loop(cursor) {
       limitCounter++
-      return client.get('friends/list', {
+      return client.get('friends/ids', {
         'user_id': twitterId,
-        'skip_status': true,
+        'stringify_ids': true,
         'include_user_entities': false,
-        count: 200, // 一度に取得できるのは200件
+        count: 5000, // 一度に取得できるのは5000件
         cursor: cursor
       }).then(result => {
-        const list = result.users.map(user => {
-          return {
-            name: user.name, // 例：なのくろ
-            twitterId: user['id_str'],
-            twitterName: user['screen_name'], // 例：nanocloudx
-            image: convertTwitterImageUrl(user['profile_image_url_https'])
-          }
-        })
-        Array.prototype.push.apply(friendsList, list)
+        Array.prototype.push.apply(friendIdsList, result.ids)
         const nextCursor = result['next_cursor']
         // 終端まで取得した、あるいはAPIを15回叩いた場合は終了
         if (nextCursor === 0 || limitCounter >= 15) {
-          resolve(friendsList)
+          resolve(friendIdsList)
         } else {
           loop(nextCursor)
         }

--- a/server/models/twitter.js
+++ b/server/models/twitter.js
@@ -78,12 +78,17 @@ export function searchTweets(cursor = null, sinceId = null) {
   })
 }
 
-export async function lookupUsers(ids) {
-  const client = new Twitter({
-    consumer_key: process.env.TWITTER_CONSUMER_KEY,
-    consumer_secret: process.env.TWITTER_CONSUMER_SECRET,
-    bearer_token: process.env.TWITTER_BEARER_TOKEN
-  })
+export async function lookupUsers(ids, _twitterId, tokenKey, tokenSecret) {
+  const twitterAuth = Object.assign(
+    {
+      consumer_key: process.env.TWITTER_CONSUMER_KEY,
+      consumer_secret: process.env.TWITTER_CONSUMER_SECRET
+    },
+    tokenKey && tokenSecret
+      ? { access_token_key: tokenKey, access_token_secret: tokenSecret }
+      : { bearer_token: process.env.TWITTER_BEARER_TOKEN }
+  )
+  const client = new Twitter(twitterAuth)
   const result = await client.get('users/lookup', {user_id: ids.join(',')})
   return result.map(user => ({
     name: user.name, // 例：なのくろ

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -1,4 +1,4 @@
-import {User} from '../database/models/index'
+import {User, Op} from '../database/models/index'
 
 /**
  * ユーザーをIdから取得します
@@ -16,6 +16,17 @@ export function fetchUserById(userId) {
  */
 export function fetchUserByTwitterId(twitterId) {
   return User.findOne({where: { twitterId: twitterId }})
+}
+
+export async function fetchUnregisteredTwitterIds(twitterIds) {
+  const registeredTwitterIds = await User.findAll({
+    attributes: ['twitterId'],
+    where: { twitterId: {
+      [Op.in]: twitterIds
+    } }
+  })
+  const registeredSet = new Set(registeredTwitterIds.map(user => user.twitterId))
+  return twitterIds.filter(id => !registeredSet.has(id))
 }
 
 /**


### PR DESCRIPTION
これまで: friends/list でデータを一括取得
このPR: frineds/idsでidのみ取得後、DBにないユーザはusers/lookupで取得してuserレコードを作る

frineds/idsでは5000個ずつ取得でき、bodyも小さいため、userが全て登録済みであればredisキャッシュがなくても1秒程度で取得できるようになる。
ただし、未登録ユーザが多い場合はusers/lookupが100件ずつしか動かず、DBへの登録処理も入るので、初回アクセスは遅くなる(初回のみこれまでの倍程度の時間がかかる)

懸念点:
 * 初回アクセスは前より時間がかかるようになる
    * 「フレンドの情報取得に時間がかかる場合があります…」みたいな表示を入れたほうがいいかも？
    * 初回アクセスでは未登録ユーザ情報の取得をジョブキューに積んでおく手もある
        * この場合、初回アクセス時はフレンド情報を元にしたサークル情報の更新を行わないことになる(コミケでは関係ないけど今後の話)
        *「最新の情報反映には15~20分程度時間がかかる場合があります」みたいな表示を入れる必要がありそう
 * usersテーブルのレコードがかなり増える
    * heroku-postgresのhobbyプランの上限が 10,000,000 レコードなので、流石に大丈夫だと思う
    * むしろ超えるほど使われたら喜んでいいかもしれない