### PR TITLE
docker-composeでnode-modulesはマシン内ローカルにした

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     volumes:
       - .:/src
       - ~/.yarn-cache:/root/.yarn-cache
+      - /src/node_modules
     working_dir: /src
     links:
       - postgres


### PR DESCRIPTION
ホストのものを使うと、Windowsだとnode_modules/.bin/webpackが読めなくなってハングする