### PR TITLE
不要なログが出ないようにした

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -29,11 +29,11 @@ app.disable('x-powered-by')
 app.use(helmet())
 app.use(compression())
 // app.use(favicon(path.join(dirname, 'public', 'favicon.ico')));
+app.use(express.static(path.join(dirname, 'public')))
 app.use(logger('dev'))
 app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({ extended: false }))
 app.use(cookieParser())
-app.use(express.static(path.join(dirname, 'public')))
 
 // --------------------------------------------------
 // Session

--- a/server/database/models/index.js
+++ b/server/database/models/index.js
@@ -3,7 +3,7 @@ import Sequelize from 'sequelize'
 export const Op = Sequelize.Op
 
 export const sequelize = new Sequelize(process.env.DATABASE_URL, {
-  // sequelize models options
+  logging: false
 })
 
 export const User = sequelize.define('user', {


### PR DESCRIPTION
papertrailでログが出すぎてカオスなので、Sequelizeのクエリログとstaticへのアクセスログは出さないようにして、重要な情報のみ出るようにする